### PR TITLE
docs/ add "Plan for issue resolution"

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -122,6 +122,9 @@ To show that there is an issue, tests should be able to be created, and should b
 Title: Follow project instructions regarding code and contributions
 Since Terraform is a large project with many contributors, there are established standards for code writing and testing. To ensure maximum readability of the code as well as the health of the project in the long run, these standards are enforced. In order to contribute to a solution, a requirement of the contribution is thus to follow those standards.
 
+## Plan for issue resolution
+To make a reliable and general solution, we first plan to understand where the issue occurs. We will find out where we can implement the fix as close to the root source of the issue as possible. This would mean the fix would apply for both the apply and the plan command, as well as any others that might be affected. To actually solve the issue, we aim to track the flow of terraforms diagnostics tool and pinpoint where in the process we can implement a non-invasive check if sensitive variables are being used. If sensitive variables are not being used, we do nothing. If sensitive variables are being used, we check for relevant variables in the .tfvars file and redact info such that it will not be displayed in error output.
+
 ## Code changes
 
 ### Patch


### PR DESCRIPTION
Includes text form Google Docs file with extensions according to the issue description.

closes #2 